### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Clone the repo with:
 Set up a virtual environment with:
 
     python -m venv .
-    pip install -r requirements
+    source ./bin/activate
+    pip install -r requirements.txt
 
 The `otpauth_migrate` script should then work.
 


### PR DESCRIPTION
1) Step is missing to activate the Python virtual environment
2) the `.txt` extension is missing in the `pip install` command.